### PR TITLE
Fix regex issue

### DIFF
--- a/ModuleJson.php
+++ b/ModuleJson.php
@@ -41,7 +41,7 @@ class ModuleJson  implements \Level2\Router\Rule {
 
 	private function getRouteDir($moduleName) {
 		$files = glob($this->moduleDir . '/*');
-		$match = preg_grep('/' . $this->moduleDir . '\/' . $moduleName . '/i', $files);
+		$match = preg_grep('/^' . $this->moduleDir . '\/' . $moduleName . '$/i', $files);
 		return array_values($match)[0] ?? false;
 	}
 


### PR DESCRIPTION
Reqex was not strict enough before so it was matching too many things
Anything that began with part of a module name would match